### PR TITLE
Fixed getCacheNode to return nearest non-null parent virtual node if the input node is null

### DIFF
--- a/src/bobril.js
+++ b/src/bobril.js
@@ -577,9 +577,13 @@ b = (function (window, document) {
     }
     function getCacheNode(n) {
         var s = vdomPath(n);
+        var currentNode = null;
         if (s.length == 0)
-            return null;
-        return s[s.length - 1];
+            return currentNode;
+        while (currentNode === null && s.length > 0) {
+            currentNode = s.pop();
+        }
+        return currentNode;
     }
     function finishUpdateNode(n, c, component) {
         if (component) {

--- a/src/bobril.ts
+++ b/src/bobril.ts
@@ -572,8 +572,12 @@ b = ((window: Window, document: Document): IBobrilStatic => {
 
     function getCacheNode(n: Node): IBobrilCacheNode {
         var s = vdomPath(n);
-        if (s.length == 0) return null;
-        return s[s.length - 1];
+        var currentNode: IBobrilNode = null;
+        if (s.length == 0) return currentNode;
+        while (currentNode === null && s.length > 0) {
+            currentNode = s.pop();
+        }
+        return currentNode;
     }
 
     function finishUpdateNode(n: IBobrilNode, c: IBobrilCacheNode, component: IBobrilComponent) {


### PR DESCRIPTION
If there is an event attached to a node in real DOM and the node doesn't
exist in virtual DOM, the event doesn't bubble up the virtual DOM.