### PR TITLE
new events onSelectionChange and onCaretPositionChange

### DIFF
--- a/src/bobril.onchange.d.ts
+++ b/src/bobril.onchange.d.ts
@@ -1,6 +1,6 @@
 ﻿interface ISelectionChangeEvent {
-    startPosition: number;
-    endPosition: number;
+    startPosition?: number;
+    endPosition?: number;
 }
 
 interface ICaretPositionChangeEvent {

--- a/src/bobril.onchange.d.ts
+++ b/src/bobril.onchange.d.ts
@@ -1,4 +1,15 @@
-﻿interface IBobrilComponent {
+﻿interface ISelectionChangeEvent {
+    startPosition: number;
+    endPosition: number;
+}
+
+interface ICaretPositionChangeEvent {
+    position: number;
+}
+
+interface IBobrilComponent {
     // called on input element after any change with new value (string|boolean)
-    onChange? (ctx: Object, value: any): void;
+    onChange?(ctx: Object, value: any): void;
+    onSelectionChange?(ctx: IBobrilCtx, event: ISelectionChangeEvent): void;
+    onCaretPositionChange?(ctx: IBobrilCtx, event: ICaretPositionChangeEvent): void;
 }

--- a/src/bobril.onchange.ts
+++ b/src/bobril.onchange.ts
@@ -179,6 +179,16 @@
             if (c.onSelectionChange || c.onCaretPositionChange) {
                 var sStart = (<HTMLInputElement>target).selectionStart;
                 var sEnd = (<HTMLInputElement>target).selectionEnd;
+                if (c.onCaretPositionChange) {
+                    var caretPosition = (<ModernHTMLInputElement>target).selectionDirection && (<ModernHTMLInputElement>target).selectionDirection === "backward" ? sStart : sEnd;
+                    if ((<any>ctx)[bCaretPosition] !== caretPosition) {
+                        (<any>ctx)[bCaretPosition] = caretPosition;
+                        c.onCaretPositionChange(ctx, { position: caretPosition });
+                    }
+                }
+                if (sStart === sEnd) {
+                    sStart = sEnd = undefined;
+                }
                 if (c.onSelectionChange) {
                     if ((<any>ctx)[bSelectionStart] !== sStart || (<any>ctx)[bSelectionEnd] !== sEnd) {
                         (<any>ctx)[bSelectionStart] = sStart;
@@ -189,15 +199,7 @@
                         });
                     }
                 }
-                if (c.onCaretPositionChange) {
-                    var caretPosition = (<ModernHTMLInputElement>target).selectionDirection && (<ModernHTMLInputElement>target).selectionDirection === "backward" ? sStart : sEnd;
-                    if ((<any>ctx)[bCaretPosition] !== caretPosition) {
-                        (<any>ctx)[bCaretPosition] = caretPosition;
-                        c.onCaretPositionChange(ctx, { position: caretPosition });
-                    }
-                }
             }  
-
         }
         return false;
     }

--- a/src/bobril.onchange.ts
+++ b/src/bobril.onchange.ts
@@ -3,7 +3,14 @@
 
 ((b: IBobrilStatic) => {
     var bvalue = "b$value";
+    var bSelectionStart = "b$selectionStart";
+    var bSelectionEnd = "b$selectionEnd";
+    var bCaretPosition = "b$caretPosition";
     var tvalue = "value";
+
+    interface ModernHTMLInputElement extends HTMLInputElement {
+        selectionDirection: string;
+    }
 
     function isCheckboxlike(el: HTMLInputElement) {
         var t = el.type;
@@ -118,19 +125,19 @@
         var c = node.component;
         if (!c)
             return false;
-        if (!c.onChange)
+        if (!c.onChange && !c.onSelectionChange && !c.onCaretPositionChange)
             return false;
         var ctx = node.ctx;
         var tagName = (<Element>target).tagName;
         var isSelect = tagName === "SELECT";
         var isMultiSelect = isSelect && (<HTMLSelectElement>target).multiple;
-        if (isMultiSelect) {
+        if (c.onChange && isMultiSelect) {
             var vs = selectedArray(<HTMLSelectElement>(<HTMLSelectElement>target).options);
             if (!stringArrayEqual((<any>ctx)[bvalue], vs)) {
                 (<any>ctx)[bvalue] = vs;
                 c.onChange(ctx, vs);
             }
-        } else if (isCheckboxlike(<HTMLInputElement>target)) {
+        } else if (c.onChange && isCheckboxlike(<HTMLInputElement>target)) {
             // Postpone change event so onClick will be processed before it
             if (ev && ev.type === "change") {
                 setTimeout(() => {
@@ -162,11 +169,35 @@
                 }
             }
         } else {
-            var v = (<HTMLInputElement>target).value;
-            if ((<any>ctx)[bvalue] !== v) {
-                (<any>ctx)[bvalue] = v;
-                c.onChange(ctx, v);
+            if(c.onChange) {
+                var v = (<HTMLInputElement>target).value;
+                if((<any>ctx)[bvalue] !== v) {
+                    (<any>ctx)[bvalue] = v;
+                    c.onChange(ctx, v);
+                }
             }
+            if (c.onSelectionChange || c.onCaretPositionChange) {
+                var sStart = (<HTMLInputElement>target).selectionStart;
+                var sEnd = (<HTMLInputElement>target).selectionEnd;
+                if (c.onSelectionChange) {
+                    if ((<any>ctx)[bSelectionStart] !== sStart || (<any>ctx)[bSelectionEnd] !== sEnd) {
+                        (<any>ctx)[bSelectionStart] = sStart;
+                        (<any>ctx)[bSelectionEnd] = sEnd;
+                        c.onSelectionChange(ctx, {
+                            startPosition: sStart,
+                            endPosition: sEnd
+                        });
+                    }
+                }
+                if (c.onCaretPositionChange) {
+                    var caretPosition = (<ModernHTMLInputElement>target).selectionDirection && (<ModernHTMLInputElement>target).selectionDirection === "backward" ? sStart : sEnd;
+                    if ((<any>ctx)[bCaretPosition] !== caretPosition) {
+                        (<any>ctx)[bCaretPosition] = caretPosition;
+                        c.onCaretPositionChange(ctx, { position: caretPosition });
+                    }
+                }
+            }  
+
         }
         return false;
     }


### PR DESCRIPTION
# Added new events onSelectionChange and onCaretPositionChange for IBobrilComponent.
## onSelectionChange
The event is emitted when the text selection of the _HTMLInputElement_ is created, changed or canceled. The event contains start and end position of the selected text. When selection is canceled startPosition and endPosition are _undefined_. The property startPosition is always less than endPostion - there is not reflected the direction in which the text has been selected.
## onCaretPositionChange
The event is emtited when the caret position of the _HTMLInputElement_ is changed. When the _HTMLInputElement_ has selected text the caret position depends on the direction in which the text has been selected - this applies in modern browsers Chrome, Firefox and Edge. Otherwise the caret position is determined from end position of the selection. 