### PR TITLE
event.preventDefault() is ignored by touch event listeners

### DIFF
--- a/src/bobril.js
+++ b/src/bobril.js
@@ -1170,6 +1170,19 @@ b = (function (window, document) {
     var renderFrameBegin = 0;
     var regEvents = {};
     var registryEvents;
+    var isPassiveEventHandlerSupported = false;
+    try {
+        var options = Object.defineProperty({}, "passive", {
+            get: function () {
+                isPassiveEventHandlerSupported = true;
+            }
+        });
+        window.addEventListener("test", options, options);
+        window.removeEventListener("test", options, options);
+    }
+    catch (err) {
+        isPassiveEventHandlerSupported = false;
+    }
     function addEvent(name, priority, callback) {
         if (registryEvents == null)
             registryEvents = {};
@@ -1202,7 +1215,7 @@ b = (function (window, document) {
         }
         if ("on" + eventName in window)
             el = window;
-        el.addEventListener(eventName, enhanceEvent, capture);
+        el.addEventListener(eventName, enhanceEvent, isPassiveEventHandlerSupported ? { capture: capture, passive: false } : capture);
     }
     function initEvents() {
         if (registryEvents == null)

--- a/src/bobril.ts
+++ b/src/bobril.ts
@@ -1333,6 +1333,20 @@ b = ((window: Window, document: Document): IBobrilStatic => {
             callback: (ev: any, target: Node, node: IBobrilCacheNode) => boolean;
         }>;
     };
+    var isPassiveEventHandlerSupported = false;
+
+    try {
+        const options = Object.defineProperty({}, "passive", {
+            get: function () {
+                isPassiveEventHandlerSupported = true;
+            }
+        });
+
+        window.addEventListener("test", options, options);
+        window.removeEventListener("test", options, options);
+    } catch (err) {
+        isPassiveEventHandlerSupported = false;
+    }
 
     function addEvent(
         name: string,
@@ -1368,7 +1382,7 @@ b = ((window: Window, document: Document): IBobrilStatic => {
             emitEvent(name, ev, <Node>t, n);
         }
         if ("on" + eventName in window) el = window;
-        el.addEventListener(eventName, enhanceEvent, capture);
+        el.addEventListener(eventName, enhanceEvent, isPassiveEventHandlerSupported ? { capture, passive: false } : capture);
     }
 
     function initEvents() {


### PR DESCRIPTION
Some browsers vendors decided to change default value of option **passive** of addEventListener to true for touch event listeners. It means that preventDefault() called inside touch event listener is ignored.