### PR TITLE
clear NodeArray and Node setters when routes length is changed

### DIFF
--- a/package/index.js
+++ b/package/index.js
@@ -4405,11 +4405,13 @@ function rootNodeFactory() {
             return undefined;
     }
     if (currentTransition == null) {
+        if (activeRoutes.length !== matches.length) {
+            setterOfNodesArray = [];
+            nodesArray = [];
+            while (nodesArray.length < matches.length)
+                nodesArray.push(undefined);
+        }
         activeRoutes = matches;
-        while (nodesArray.length > activeRoutes.length)
-            nodesArray.pop();
-        while (nodesArray.length < activeRoutes.length)
-            nodesArray.push(undefined);
         activeParams = out.p;
     }
     var fn = noop;

--- a/package/index.ts
+++ b/package/index.ts
@@ -5073,9 +5073,12 @@ function rootNodeFactory(): IBobrilNode | undefined {
         } else return undefined;
     }
     if (currentTransition == null) {
+        if (activeRoutes.length !== matches.length) {
+            setterOfNodesArray = [];
+            nodesArray = [];
+            while (nodesArray.length < matches.length) nodesArray.push(undefined);
+        }
         activeRoutes = matches;
-        while (nodesArray.length > activeRoutes.length) nodesArray.pop();
-        while (nodesArray.length < activeRoutes.length) nodesArray.push(undefined);
         activeParams = out.p;
     }
     var fn: (otherData?: any) => IBobrilNode | undefined = noop;


### PR DESCRIPTION
**Current state:**
- All node setters are filled with max ID depends on routes count (all nodes are set to the same array field) 
- only last item of this array are actually used.

**Problem description:**
- When count of routes is decreased, node setters are still set to previous max ID
  - It means that this ID of nodeArray is not used bcs of clear -> canDeactivate is not called
- When count of routes is increased, node setters are changed just for few new higher setters
  - It means that there is posibility to have obsolete node in nodeArray -> canDeactivate is called even if node is not rendered

**Solution:**
- Reset nodeArray and node setters when count of routes is changed
- Thanks to this, nodeArray will have only last route item every time, so just the last canDeactivate will be called.

**Solution to the future:**
- Should be nodeArray filled with all nodes used in routes?
  - Then canDeactivate can be called for all routes which are deactivated
  - We need to know future routes before first iteration of routing is called.
  - We need to keep nodeArray updated all the time.