### PR TITLE
Url address with trailing slash doesn't match pattern with no trailing slash

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -169,7 +169,7 @@ function compilePattern(pattern: string) {
         );
 
         compiledPatterns[pattern] = {
-            matcher: new RegExp("^" + source + "$", "i"),
+            matcher: new RegExp("^" + source + (pattern.endsWith("/") ? "?" : "\\/?") + "$", "i"),
             paramNames: paramNames,
         };
     }


### PR DESCRIPTION
Route pattern "/route" doesn't match url "/route/"