### PR TITLE
Adding an attribute to a bobril node affects other nodes with the same attribute

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1222,7 +1222,7 @@ export function updateNode(
                     c,
                     el,
                     n.attrs,
-                    c.attrs || emptyObject,
+                    c.attrs || {},
                     inNotFocusable
                 );
             updateNodeStyle(el as HTMLElement, n.style, enrichClassName(c, n.className), c, inSvg);


### PR DESCRIPTION
Repro - checking the checkbox should disable both buttons but disables just the first one
[bobril-bug.zip](https://github.com/Bobris/Bobril/files/6514261/bobril-bug.zip)